### PR TITLE
fixed parts about the index file, and about required files

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
           <a href="http://www.esri.com/library/whitepapers/pdfs/shapefile.pdf">specification is open</a>.</li>
         <li>For many use cases, it is <em>good enough</em>.
           <ul>
-            <li>Index files (e.g. *.shx) enable good reading performance.</li>
+            <li>Its index file (*.shx) contains the offset and length of each feature in the main file (*.shp) which enables good reading performance.</li>
             <li>It is relatively efficient in terms of file size. The resulting file, even
                     un-zipped, is relatively small compared to some other (mostly
                     text-based) formats.
@@ -121,7 +121,7 @@
     <p>
     The Shapefile format uses <a
        href="https://en.wikipedia.org/wiki/Shapefile#Overview">at least 3
-       files</a> (*.shp, *.dbf, *.prj). Users cannot share just one file; you 
+       files</a> (*.shp, *.shx, *.dbf). Users cannot share just one file; you 
        must send them all. Users typically zip all the files into one archive
        and unzip them on the other end of the distribution chain, but this is 
        cumbersome and error-prone.


### PR DESCRIPTION
The bit about the *shx file wasn't quite correct, and I thought a little misleading. There are other indexing sidecar files that Esri uses, that provide the improved reading performance you're referring to, aren't part of the universal spec, so I didn't mention those.

I edited the section "Multifile format" because it contained an error about which 3 files are required. It says shp, dbf, prj, but it's actually shp, shx, dbf.