### PR TITLE
remove must die wording

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8">
 
-  <title>Shapefile must die!</title>
+  <title>Switch from Shapefile!</title>
   <meta name="description" content="Page explaining why Esri Shapefile is a flawed format and that other alternatives should be used.">
   <meta name="author" content="Jachym Cepicky - OpenGeoLabs.cz">
   <meta name="keywords" content="gis,#g,shapefile,ESRI Shapefile,bad,get rid of,die">


### PR DESCRIPTION
In a professional setting, the wording `must die` is strange. The website would be really good to be used to educate users.